### PR TITLE
Clear global state when kernel restarts to allow JS/CSS to reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+jp_proxy_widget/static
+js/node_modules
+js/package-lock.json

--- a/js/lib/proxy_implementation.js
+++ b/js/lib/proxy_implementation.js
@@ -66,6 +66,10 @@ var JSProxyView = widgets.DOMWidgetView.extend({
         that.$$el.jQuery = jquery_;
         that.$$el._ = _;
 
+        Jupyter.notebook.events.on("kernel_ready.Kernel",function() {
+            that.clear_global_state(jquery_);
+        });
+
         // trigger callbacks if vanilla javascript modules have/have not been loaded.
         // no-op callbacks can be falsy.
         that.$$el.test_js_loaded = function(names, is_loaded_callback, not_loaded_callback, silent) {
@@ -239,6 +243,16 @@ var JSProxyView = widgets.DOMWidgetView.extend({
 
         that.model.set("rendered", true);
         that.touch();
+    },
+
+    clear_global_state: function(jq) {
+        console.log("Clearing jp_proxy_widget global state");
+        // Clear any global state here
+        var that = this;
+
+        that.loaded_js_by_name = {};
+        // get rid of all nodes that were loaded via jp-proxy-widget
+        jq("[data-jp-proxy-widget-node]").each(function(idx,e){e.remove();});
     },
 
     set_error_msg: function(message) {
@@ -505,6 +519,7 @@ var JSProxyView = widgets.DOMWidgetView.extend({
             .prop("type", "text/css")
             //.prop("title", css_name)
             .prop("href", css_name)
+            .attr("data-jp-proxy-widget-node","1")
             .html("\n"+css_text)
             .appendTo("head");
             // loop a while waiting for the stylesheet to appear.


### PR DESCRIPTION
JS: clear `that.loaded_js_by_name`
CSS: remove all notes with data attribute `data-jp-proxy-widget-node`

This allows CSS/JS to be reloaded without reloading the page. Also in the
future, nodes can be added using the `data-jp-proxy-widget-node` attribute and
automatically be cleared in a similar way.

The main reason this is needed is if you are editing CSS/JS while developing 
a widget, it's quite cumbersome to have to reload the page and then restart the
kernel. This makes it so only a kernel restart is necessary and allows for quicker
iteration and fewer surprises.